### PR TITLE
[FEAT] Basic rendering system

### DIFF
--- a/render/custom.go
+++ b/render/custom.go
@@ -1,6 +1,9 @@
 package render
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+)
 
 func (r *RealRenderer) renderCustom(md []byte, config *RenderConfig) ([]byte, error) {
 	var err error
@@ -22,16 +25,18 @@ func (r *RealRenderer) renderSingleline(md []byte, config *RenderConfig) ([]byte
 		return md, nil
 	}
 
-	total, tag, param := match[0], string(match[1]), string(match[2])
+	total, tag, param := match[0], match[1], match[2]
 
 	var newMarkdown bytes.Buffer
-	switch tag {
+	switch string(tag) {
 	case "include":
-		include, err := r.source.LoadInclude(param)
+		include, err := r.source.LoadInclude(string(param))
 		if err != nil {
 			return []byte{}, err
 		}
 		newMarkdown.Write(include)
+	default:
+		newMarkdown.Write(fmt.Appendf(nil, "Tag %s does not exist\n", tag))
 	}
 
 	md = bytes.Replace(md, total, newMarkdown.Bytes(), 1)
@@ -44,12 +49,15 @@ func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) ([]byte,
 		return md, nil
 	}
 
-	total, tag, body := match[0], string(match[1]), match[2]
+	total, tag, body := match[0], match[1], match[2]
 
 	var newMarkdown bytes.Buffer
-	switch tag {
+	switch string(tag) {
 	case "warning":
-        newMarkdown.Write([]byte("Warning:\n"))
+		newMarkdown.Write([]byte("Warning:\n"))
+		newMarkdown.Write(body)
+	default:
+		newMarkdown.Write(fmt.Appendf(nil, "Tag %s does not exist\n", tag))
 		newMarkdown.Write(body)
 	}
 

--- a/render/custom.go
+++ b/render/custom.go
@@ -49,7 +49,7 @@ func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) ([]byte,
 	var newMarkdown bytes.Buffer
 	switch tag {
 	case "warning":
-		newMarkdown.Write([]byte("Warning !\n"))
+        newMarkdown.Write([]byte("Warning:\n"))
 		newMarkdown.Write(body)
 	}
 

--- a/render/custom.go
+++ b/render/custom.go
@@ -12,38 +12,36 @@ func (r *RealRenderer) renderCustom(md []byte, config *RenderConfig) []byte {
 }
 
 func (r *RealRenderer) renderSingleline(md []byte, config *RenderConfig) []byte {
-	match := r.singleline.Find(md)
+	match := r.singleline.FindSubmatch(md)
 	if match == nil {
 		return md
 	}
 
-	submatches := r.singleline.FindSubmatch(match)
-	html := r.renderSingleHTML(submatches[0], submatches[1], config)
+	html := r.renderSingleHTML(match[1], match[2], config)
 
-	md = bytes.Replace(md, match, html, 1)
+	md = bytes.Replace(md, match[0], html, 1)
 	return r.renderSingleline(md, config)
 }
 
 func (r *RealRenderer) renderSingleHTML(tag, param []byte, config *RenderConfig) []byte {
-	log.Printf("tag: %s\nparam: %s\n", tag, param)
+	log.Printf("\ntag: %s\nparam: %s\n", tag, param)
 	return []byte("Jesus Christ")
 }
 
 func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) []byte {
-	match := r.multiline.Find(md)
+	match := r.multiline.FindSubmatch(md)
 	if match == nil {
 		return md
 	}
 
-	submatches := r.multiline.FindSubmatch(match)
 	var html []byte
-	if len(submatches) == 2 {
-		html = r.renderMultiHTML(submatches[0], nil, submatches[1], config)
-	} else if len(submatches) == 3 {
-		html = r.renderMultiHTML(submatches[0], submatches[1], submatches[2], config)
+	if len(match) == 3 {
+		html = r.renderMultiHTML(match[1], nil, match[2], config)
+	} else if len(match) == 4 {
+		html = r.renderMultiHTML(match[1], match[2], match[3], config)
 	}
 
-	md = bytes.Replace(md, match, html, 1)
+	md = bytes.Replace(md, match[0], html, 1)
 	return r.renderMultiline(md, config)
 }
 

--- a/render/custom.go
+++ b/render/custom.go
@@ -20,13 +20,13 @@ func (r *RealRenderer) renderSingleline(md []byte, config *RenderConfig) []byte 
 	submatches := r.singleline.FindSubmatch(match)
 	html := r.renderSingleHTML(submatches[0], submatches[1], config)
 
-	bytes.Replace(md, match, html, 1)
+	md = bytes.Replace(md, match, html, 1)
 	return r.renderSingleline(md, config)
 }
 
 func (r *RealRenderer) renderSingleHTML(tag, param []byte, config *RenderConfig) []byte {
-    log.Printf("tag: %s\nparam: %s\n", tag, param)
-	return []byte{}
+	log.Printf("tag: %s\nparam: %s\n", tag, param)
+	return []byte("Jesus Christ")
 }
 
 func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) []byte {
@@ -43,11 +43,11 @@ func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) []byte {
 		html = r.renderMultiHTML(submatches[0], submatches[1], submatches[2], config)
 	}
 
-	bytes.Replace(md, match, html, 1)
+	md = bytes.Replace(md, match, html, 1)
 	return r.renderMultiline(md, config)
 }
 
 func (r *RealRenderer) renderMultiHTML(tag, param, body []byte, config *RenderConfig) []byte {
-    log.Printf("tag: %s\nparam: %s\nbody: %s\n", tag, param, body)
-	return []byte{}
+	log.Printf("\ntag: %s\nparam: %s\nbody: %s\n", tag, param, body)
+	return []byte("Jesus Christ")
 }

--- a/render/custom.go
+++ b/render/custom.go
@@ -1,22 +1,53 @@
 package render
 
 import (
+	"bytes"
 	"log"
-	"regexp"
 )
 
-func (r *RealRenderer) renderCustom(md []byte, config *RenderConfig) ([]byte, error) {
-	multiline, err := regexp.Compile(`(?m)^{ *([a-z]+)(?: *\"(.*)\")? *}\n?((?:.|\n)*?)\n?{/}$`)
-	if err != nil {
-		return []byte{}, err
-	}
-	log.Printf("%s\n", multiline.FindAll(md, -1))
+func (r *RealRenderer) renderCustom(md []byte, config *RenderConfig) []byte {
+	md = r.renderSingleline(md, config)
+	md = r.renderMultiline(md, config)
+	return md
+}
 
-	singleline, err := regexp.Compile(`(?m)^{ *([a-z]+)(?: *\"(.*)\")? */}$`)
-	if err != nil {
-		return []byte{}, err
+func (r *RealRenderer) renderSingleline(md []byte, config *RenderConfig) []byte {
+	match := r.singleline.Find(md)
+	if match == nil {
+		return md
 	}
-	log.Printf("%s\n", singleline.FindAll(md, -1))
 
-	return md, nil
+	submatches := r.singleline.FindSubmatch(match)
+	html := r.renderSingleHTML(submatches[0], submatches[1], config)
+
+	bytes.Replace(md, match, html, 1)
+	return r.renderSingleline(md, config)
+}
+
+func (r *RealRenderer) renderSingleHTML(tag, param []byte, config *RenderConfig) []byte {
+    log.Printf("tag: %s\nparam: %s\n", tag, param)
+	return []byte{}
+}
+
+func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) []byte {
+	match := r.multiline.Find(md)
+	if match == nil {
+		return md
+	}
+
+	submatches := r.multiline.FindSubmatch(match)
+	var html []byte
+	if len(submatches) == 2 {
+		html = r.renderMultiHTML(submatches[0], nil, submatches[1], config)
+	} else if len(submatches) == 3 {
+		html = r.renderMultiHTML(submatches[0], submatches[1], submatches[2], config)
+	}
+
+	bytes.Replace(md, match, html, 1)
+	return r.renderMultiline(md, config)
+}
+
+func (r *RealRenderer) renderMultiHTML(tag, param, body []byte, config *RenderConfig) []byte {
+    log.Printf("tag: %s\nparam: %s\nbody: %s\n", tag, param, body)
+	return []byte{}
 }

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -30,7 +30,7 @@ func NewRealRenderer(source source.Source) (Renderer, error) {
 		return nil, err
 	}
 
-	multiline, err := regexp.Compile(`(?m)^{ *([a-z]+)(?: *\"(.*)\")? *}\n?((?:.|\n)*?)\n?{/}$`)
+	multiline, err := regexp.Compile(`(?m)^{ *([a-z]+) *}\n?((?:.|\n)*?)\n?{/}$`)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,10 @@ func (r *RealRenderer) RenderFile(path string, config *RenderConfig) ([]byte, er
 		return []byte{}, err
 	}
 
-	custom := r.renderCustom(file, config)
+	custom, err := r.renderCustom(file, config)
+	if err != nil {
+		return []byte{}, err
+	}
 	doc := r.parseMarkdown(custom, config)
 	doc = r.fixupAST(doc, config)
 	html := r.renderHTML(doc, config)

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -65,10 +65,7 @@ func (r *RealRenderer) RenderFile(path string, config *RenderConfig) ([]byte, er
 		return []byte{}, err
 	}
 
-	custom, err := r.renderCustom(file, config)
-	if err != nil {
-		return []byte{}, err
-	}
+	custom := r.renderCustom(file, config)
 	doc := r.parseMarkdown(custom, config)
 	doc = r.fixupAST(doc, config)
 	html := r.renderHTML(doc, config)

--- a/source/source.go
+++ b/source/source.go
@@ -109,7 +109,7 @@ func (s *GitSource) LoadInclude(path string) ([]byte, error) {
 		return []byte{}, fmt.Errorf("This entered file path \"%s\" is not valid !", path)
 	}
 
-	fileName := fmt.Sprintf("%s/.common/includes/%s.md", s.dataPath, strings.Trim(path, "/"))
+	fileName := fmt.Sprintf("%s/.common/includes%s.md", s.dataPath, utils.FormatLocalPathString(path, ".md"))
 
 	if _, err := os.Stat(fileName); err != nil {
 		return []byte{}, err

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 )
 
@@ -34,5 +33,5 @@ func FormatLocalPathString(path, ext string) string {
 func FormatLocalPath(path []byte, ext string) []byte {
 	trim := bytes.Trim(path, "/")
 	trim = bytes.TrimSuffix(trim, []byte(ext))
-	return slices.Concat([]byte("/"), trim)
+	return fmt.Appendf(nil, "/%s", trim)
 }


### PR DESCRIPTION
## Summary of the PR
Add a basic rendering system to replace custom tag

## Steps before PR review

- [x] Validate all checks
- [x] Fix regex not matching capture groups properly
- [x] Add defaults for the switches of tags
- [x] Document changes properly

* Issues linked to the PR: #8 

## Changes

- Make `renderSingleline` & `renderMultiline` to separate functions to allow for recursive searching
- Data is matched using regex capture groups which are then processed by switch of the input tag
- Remove param from multiline regex
- Fix path formatting in `source.LoadInclude`
- Use `fmt.Appendf` instead of `slices.Concat` in path formatting utils