### PR TITLE
[FEAT] Add syntax highlighting for code blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Config struct {
-	Domain        string
-	Host          string
-	Port          string
-	DataPath      string // where to clone the repository
-	Repository    string // the reposityory to get the pages from
-	WebhookSecret string // the secret to use to validate the webhook
-	HomePage      string // the page to render at /
+	Domain                string
+	Host                  string
+	Port                  string
+	DataPath              string // where to clone the repository
+	Repository            string // the reposityory to get the pages from
+	WebhookSecret         string // the secret to use to validate the webhook
+	HomePage              string // the page to render at /
+	DefaultHighlightStyle string
 }
 
 func LoadConfig() *Config {
@@ -24,13 +25,14 @@ func LoadConfig() *Config {
 	log.Printf("[Config] Loading environment variables...")
 
 	return &Config{
-		Domain:        getEnv("DOMAIN"),
-		Host:          getEnv("HOST"),
-		Port:          getDefaultEnv("PORT", "80"),
-		DataPath:      utils.FormatLocalPathString(getDefaultEnv("DATA_PATH", "/docs/data"), ""),
-		Repository:    getEnv("REPOSITORY"),
-		WebhookSecret: getEnv("WEBHOOK_SECRET"),
-		HomePage:      utils.FormatLocalPathString(getDefaultEnv("HOME_PAGE", "index.md"), ".md"),
+		Domain:                getEnv("DOMAIN"),
+		Host:                  getEnv("HOST"),
+		Port:                  getDefaultEnv("PORT", "80"),
+		DataPath:              utils.FormatLocalPathString(getDefaultEnv("DATA_PATH", "/docs/data"), ""),
+		Repository:            getEnv("REPOSITORY"),
+		WebhookSecret:         getEnv("WEBHOOK_SECRET"),
+		HomePage:              utils.FormatLocalPathString(getDefaultEnv("HOME_PAGE", "index.md"), ".md"),
+		DefaultHighlightStyle: "tokyonight",
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,9 @@ require (
 	github.com/joho/godotenv v1.5.1
 )
 
-require github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+require (
+	github.com/alecthomas/chroma/v2 v2.17.2
+	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+)
+
+require github.com/dlclark/regexp2 v1.11.5 // indirect

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -86,6 +86,7 @@ func (h *Handler) handleDocsPath(w http.ResponseWriter, r *http.Request, path st
 		renderConfig.RootPath = utils.FormatLocalPathString(root, "")
 	}
 	_, renderConfig.UseTailwind = r.URL.Query()["tailwind"]
+	renderConfig.StyleName = r.URL.Query().Get("styleName")
 
 	html, err := h.renderer.RenderFile(path, renderConfig)
 	if err != nil {

--- a/render/custom.go
+++ b/render/custom.go
@@ -3,6 +3,7 @@ package render
 import (
 	"bytes"
 	"fmt"
+	"io"
 )
 
 func (r *RealRenderer) renderCustom(md []byte, config *RenderConfig) ([]byte, error) {
@@ -36,7 +37,7 @@ func (r *RealRenderer) renderSingleline(md []byte, config *RenderConfig) ([]byte
 		}
 		newMarkdown.Write(include)
 	default:
-		newMarkdown.Write(fmt.Appendf(nil, "Tag %s does not exist\n", tag))
+		io.WriteString(&newMarkdown, fmt.Sprintf("Tag %s does not exist\n", tag))
 	}
 
 	md = bytes.Replace(md, total, newMarkdown.Bytes(), 1)
@@ -54,10 +55,10 @@ func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) ([]byte,
 	var newMarkdown bytes.Buffer
 	switch string(tag) {
 	case "warning":
-		newMarkdown.Write([]byte("Warning:\n"))
+        io.WriteString(&newMarkdown, "Warning:\n")
 		newMarkdown.Write(body)
 	default:
-		newMarkdown.Write(fmt.Appendf(nil, "Tag %s does not exist\n", tag))
+		io.WriteString(&newMarkdown, fmt.Sprintf("Tag %s does not exist\n", tag))
 		newMarkdown.Write(body)
 	}
 

--- a/render/custom.go
+++ b/render/custom.go
@@ -55,7 +55,7 @@ func (r *RealRenderer) renderMultiline(md []byte, config *RenderConfig) ([]byte,
 	var newMarkdown bytes.Buffer
 	switch string(tag) {
 	case "warning":
-        io.WriteString(&newMarkdown, "Warning:\n")
+		io.WriteString(&newMarkdown, "Warning:\n")
 		newMarkdown.Write(body)
 	default:
 		io.WriteString(&newMarkdown, fmt.Sprintf("Tag %s does not exist\n", tag))

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -1,14 +1,16 @@
 package render
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/gomarkdown/markdown/ast"
 )
 
-func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) error {
+func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool, config *RenderConfig) error {
 	lang := string(codeBlock.Info)
 	source := string(codeBlock.Literal)
 	l := lexers.Get(lang)
@@ -25,5 +27,15 @@ func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, en
 		return err
 	}
 
-	return r.htmlFormatter.Format(w, r.highlightStyle, iterator)
+	return r.htmlFormatter.Format(w, config.highlightStyle, iterator)
+}
+
+func (r *RealRenderer) getHighlightStyle(config *RenderConfig) error {
+	styleName := "tokyonight"
+	config.highlightStyle = styles.Get(styleName)
+	if config.highlightStyle == nil {
+		return fmt.Errorf("Couldn't find style %s", styleName)
+	}
+
+	return nil
 }

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -9,7 +9,11 @@ import (
 )
 
 func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) error {
-	// TODO: make sure rest of paragraph is rendered properly
+	_, err := io.WriteString(w, "\n<pre><code>\n")
+	if err != nil {
+		return err
+	}
+
 	lang := string(codeBlock.Info)
 	source := string(codeBlock.Literal)
 	l := lexers.Get(lang)
@@ -25,5 +29,12 @@ func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, en
 	if err != nil {
 		return err
 	}
-	return r.htmlFormatter.Format(w, r.highlightStyle, iterator)
+
+	err = r.htmlFormatter.Format(w, r.highlightStyle, iterator)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.WriteString(w, "\n</pre></code>\n")
+	return err
 }

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -3,8 +3,27 @@ package render
 import (
 	"io"
 
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/gomarkdown/markdown/ast"
 )
 
-func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) {
+func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) error {
+	// TODO: make sure rest of paragraph is rendered properly
+	lang := string(codeBlock.Info)
+	source := string(codeBlock.Literal)
+	l := lexers.Get(lang)
+	if l == nil {
+		l = lexers.Analyse(source)
+	}
+	if l == nil {
+		l = lexers.Fallback
+	}
+	l = chroma.Coalesce(l)
+
+	iterator, err := l.Tokenise(nil, source)
+	if err != nil {
+		return err
+	}
+	return r.htmlFormatter.Format(w, r.highlightStyle, iterator)
 }

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -9,11 +9,6 @@ import (
 )
 
 func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) error {
-	_, err := io.WriteString(w, "\n<pre><code>\n")
-	if err != nil {
-		return err
-	}
-
 	lang := string(codeBlock.Info)
 	source := string(codeBlock.Literal)
 	l := lexers.Get(lang)
@@ -30,11 +25,5 @@ func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, en
 		return err
 	}
 
-	err = r.htmlFormatter.Format(w, r.highlightStyle, iterator)
-	if err != nil {
-		return err
-	}
-
-	_, err = io.WriteString(w, "\n</pre></code>\n")
-	return err
+	return r.htmlFormatter.Format(w, r.highlightStyle, iterator)
 }

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -31,7 +31,11 @@ func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, en
 }
 
 func (r *RealRenderer) getHighlightStyle(config *RenderConfig) error {
-	styleName := "tokyonight"
+	styleName := config.StyleName
+	if styleName == "" {
+		styleName = "tokyonight"
+	}
+
 	config.highlightStyle = styles.Get(styleName)
 	if config.highlightStyle == nil {
 		return fmt.Errorf("Couldn't find style %s", styleName)

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -1,0 +1,10 @@
+package render
+
+import (
+	"io"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, entering bool) {
+}

--- a/render/render.go
+++ b/render/render.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"bytes"
+	"io"
 	"slices"
 
 	"github.com/PiquelOrganization/docs.piquel.fr/utils"
@@ -33,10 +34,24 @@ func (r *RealRenderer) renderHTML(doc ast.Node, config *RenderConfig) []byte {
 		htmlFlags = htmlFlags | html.CompletePage
 	}
 
-	options := html.RendererOptions{Flags: htmlFlags}
+	options := html.RendererOptions{
+		Flags:          htmlFlags,
+		RenderNodeHook: r.renderHook(config),
+	}
 	renderer := html.NewRenderer(options)
 
 	return markdown.Render(doc, renderer)
+}
+
+func (r *RealRenderer) renderHook(config *RenderConfig) html.RenderNodeFunc {
+	return func(w io.Writer, node ast.Node, entering bool) (ast.WalkStatus, bool) {
+		switch node := node.(type) {
+		case *ast.CodeBlock:
+			r.renderCodeBlock(w, node, entering)
+			return ast.GoToNext, true
+		}
+		return ast.GoToNext, false
+	}
 }
 
 func (r *RealRenderer) addStyles(html []byte, config *RenderConfig) []byte {

--- a/render/render.go
+++ b/render/render.go
@@ -47,7 +47,7 @@ func (r *RealRenderer) renderHook(config *RenderConfig) html.RenderNodeFunc {
 	return func(w io.Writer, node ast.Node, entering bool) (ast.WalkStatus, bool) {
 		switch node := node.(type) {
 		case *ast.CodeBlock:
-			r.renderCodeBlock(w, node, entering)
+			r.renderCodeBlock(w, node, entering, config)
 			return ast.GoToNext, true
 		}
 		return ast.GoToNext, false

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PiquelOrganization/docs.piquel.fr/source"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters/html"
-	"github.com/alecthomas/chroma/v2/styles"
 )
 
 type Renderer interface {

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -1,9 +1,13 @@
 package render
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/PiquelOrganization/docs.piquel.fr/source"
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
 )
 
 type Renderer interface {
@@ -20,8 +24,10 @@ type RenderConfig struct {
 type RealRenderer struct {
 	source source.Source
 
-	singleline *regexp.Regexp
-	multiline  *regexp.Regexp
+	singleline     *regexp.Regexp
+	multiline      *regexp.Regexp
+	htmlFormatter  *html.Formatter
+	highlightStyle *chroma.Style
 }
 
 func NewRealRenderer(source source.Source) (Renderer, error) {
@@ -35,11 +41,18 @@ func NewRealRenderer(source source.Source) (Renderer, error) {
 		return nil, err
 	}
 
-	return &RealRenderer{
-		source:     source,
-		singleline: singleline,
-		multiline:  multiline,
-	}, nil
+	htmlFormatter := html.New()
+	if htmlFormatter == nil {
+		return nil, fmt.Errorf("Error creating html formatter")
+	}
+
+	styleName := "tokyonight"
+	highlightStyle := styles.Get(styleName)
+	if highlightStyle == nil {
+		return nil, fmt.Errorf("Couldn't find style %s", styleName)
+	}
+
+	return &RealRenderer{source, singleline, multiline, htmlFormatter, highlightStyle}, nil
 }
 
 func (r *RealRenderer) RenderAllFiles(config *RenderConfig) (map[string][]byte, error) {


### PR DESCRIPTION
## Summary of the PR
Add syntax highlighting to markdown code blocks

## Steps before PR review

- [x] Validate all checks
- [x] Properly document the feature in the PR (and docs when we have some)
- [x] Get style from param (default to tokyonight)

* Issues linked to the PR: #9 

## Changes

- Use `io.WriteString` insread of `fmt.Appendf`
- Add highlighting file with higlighting logic (uses [alecthomas/chroma](https://github.com/alecthomas/chroma))
- Uses render hook to render the code blocks
- Init formatter in renderer factory
- Style in query parameter, default "tokyonight" is stored in config