### PR TITLE
[CHANGE] Configuration refactor

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type Envs struct {
 
 type DocsConfig struct {
 	sync.Mutex
-	HomePage       string `yaml:"home_page" json:"home_page"`             // the page to render at /
+	HomePage       string `yaml:"home_page"`                              // the page to render at / (only used in docsConfig, not used in rendering process so dont send when requesting a page)
 	HighlightStyle string `yaml:"highlight_style" json:"highlight_style"` // The name of the style used to format code blocks
 	Root           string `yaml:"root" json:"root"`                       // this will be prepended to any local URLs in the markdown
 	UseTailwind    bool   `yaml:"tailwind" json:"tailwind"`               // wether to use tailwind classes and settings (notably restore the proper size of titles)

--- a/config/config.go
+++ b/config/config.go
@@ -10,9 +10,8 @@ import (
 )
 
 type Config struct {
-	sync.Mutex
-	Envs   Envs
-	Config DocsConfig
+	Envs   Envs       // the technical server configuration
+	Config DocsConfig // the documentation specific configuration
 }
 
 type Envs struct {
@@ -25,6 +24,7 @@ type Envs struct {
 }
 
 type DocsConfig struct {
+	sync.Mutex
 	HomePage       string `json:"home_page"`       // the page to render at /
 	HighlightStyle string `json:"highlight_style"` // the style used to highlight code
 	Root           string `json:"root"`            // the root used to return

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ type DocsConfig struct {
 	HomePage       string `yaml:"home_page" json:"home_page"`             // the page to render at /
 	HighlightStyle string `yaml:"highlight_style" json:"highlight_style"` // The name of the style used to format code blocks
 	Root           string `yaml:"root" json:"root"`                       // this will be prepended to any local URLs in the markdown
-	UseTailwind    bool   `yaml:"use_tailwind" json:"tailwind"`           // wether to use tailwind classes and settings (notably restore the proper size of titles)
+	UseTailwind    bool   `yaml:"tailwind" json:"tailwind"`               // wether to use tailwind classes and settings (notably restore the proper size of titles)
 	FullPage       bool   `yaml:"full_page" json:"full_page"`             // wether to render a full page (add <!DOCTYPE html> to the top of the page
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,10 +25,10 @@ type Envs struct {
 
 type DocsConfig struct {
 	sync.Mutex
-	HomePage       string `json,yaml:"home_page"`       // the page to render at /
-	HighlightStyle string `json,yaml:"highlight_style"` // the style used to highlight code
-	Root           string `json,yaml:"root"`            // the root used to return
-	UseTailwind    bool   `json,yaml:"use_tailwind"`    // wether to add classes to reverse tailwind config
+	HomePage       string `yaml:"home_page" json:"home_page"`             // the page to render at /
+	HighlightStyle string `yaml:"highlight_style" json:"highlight_style"` // the style used to highlight code
+	Root           string `yaml:"root" json:"root"`                       // the root used to return
+	UseTailwind    bool   `yaml:"use_tailwind" json:"use_tailwind"`       // wether to add classes to reverse tailwind config
 }
 
 func LoadConfig() *Config {
@@ -45,7 +45,7 @@ func LoadConfig() *Config {
 			Repository:    getEnv("REPOSITORY"),
 			WebhookSecret: getEnv("WEBHOOK_SECRET")},
 		Config: DocsConfig{
-			HomePage:       "index.md",
+			HomePage:       "index",
 			HighlightStyle: "tokyonight",
 			Root:           "",
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -26,9 +26,10 @@ type Envs struct {
 type DocsConfig struct {
 	sync.Mutex
 	HomePage       string `yaml:"home_page" json:"home_page"`             // the page to render at /
-	HighlightStyle string `yaml:"highlight_style" json:"highlight_style"` // the style used to highlight code
-	Root           string `yaml:"root" json:"root"`                       // the root used to return
-	UseTailwind    bool   `yaml:"use_tailwind" json:"use_tailwind"`       // wether to add classes to reverse tailwind config
+	HighlightStyle string `yaml:"highlight_style" json:"highlight_style"` // The name of the style used to format code blocks
+	Root           string `yaml:"root" json:"root"`                       // this will be prepended to any local URLs in the markdown
+	UseTailwind    bool   `yaml:"use_tailwind" json:"tailwind"`           // wether to use tailwind classes and settings (notably restore the proper size of titles)
+	FullPage       bool   `yaml:"full_page" json:"full_page"`             // wether to render a full page (add <!DOCTYPE html> to the top of the page
 }
 
 func LoadConfig() *Config {

--- a/config/config.go
+++ b/config/config.go
@@ -3,20 +3,31 @@ package config
 import (
 	"log"
 	"os"
+	"sync"
 
 	"github.com/PiquelOrganization/docs.piquel.fr/utils"
 	"github.com/joho/godotenv"
 )
 
 type Config struct {
-	Domain                string
-	Host                  string
-	Port                  string
-	DataPath              string // where to clone the repository
-	Repository            string // the reposityory to get the pages from
-	WebhookSecret         string // the secret to use to validate the webhook
-	HomePage              string // the page to render at /
-	DefaultHighlightStyle string
+	sync.Mutex
+	Envs   Envs
+	Config DocsConfig
+}
+
+type Envs struct {
+	Domain        string
+	Host          string
+	Port          string
+	DataPath      string // where to clone the repository
+	Repository    string // the reposityory to get the pages from
+	WebhookSecret string // the secret to use to validate the webhook
+}
+
+type DocsConfig struct {
+	HomePage       string `json:"home_page"`       // the page to render at /
+	HighlightStyle string `json:"highlight_style"` // the style used to highlight code
+	Root           string `json:"root"`            // the root used to return
 }
 
 func LoadConfig() *Config {
@@ -25,14 +36,18 @@ func LoadConfig() *Config {
 	log.Printf("[Config] Loading environment variables...")
 
 	return &Config{
-		Domain:                getEnv("DOMAIN"),
-		Host:                  getEnv("HOST"),
-		Port:                  getDefaultEnv("PORT", "80"),
-		DataPath:              utils.FormatLocalPathString(getDefaultEnv("DATA_PATH", "/docs/data"), ""),
-		Repository:            getEnv("REPOSITORY"),
-		WebhookSecret:         getEnv("WEBHOOK_SECRET"),
-		HomePage:              utils.FormatLocalPathString(getDefaultEnv("HOME_PAGE", "index.md"), ".md"),
-		DefaultHighlightStyle: "tokyonight",
+		Envs: Envs{
+			Domain:        getEnv("DOMAIN"),
+			Host:          getEnv("HOST"),
+			Port:          getDefaultEnv("PORT", "80"),
+			DataPath:      utils.FormatLocalPathString(getDefaultEnv("DATA_PATH", "/docs/data"), ""),
+			Repository:    getEnv("REPOSITORY"),
+			WebhookSecret: getEnv("WEBHOOK_SECRET")},
+		Config: DocsConfig{
+			HomePage:       "index.md",
+			HighlightStyle: "tokyonight",
+			Root:           "",
+		},
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,10 @@ type Envs struct {
 
 type DocsConfig struct {
 	sync.Mutex
-	HomePage       string `json:"home_page"`       // the page to render at /
-	HighlightStyle string `json:"highlight_style"` // the style used to highlight code
-	Root           string `json:"root"`            // the root used to return
+	HomePage       string `json,yaml:"home_page"`       // the page to render at /
+	HighlightStyle string `json,yaml:"highlight_style"` // the style used to highlight code
+	Root           string `json,yaml:"root"`            // the root used to return
+	UseTailwind    bool   `json,yaml:"use_tailwind"`    // wether to add classes to reverse tailwind config
 }
 
 func LoadConfig() *Config {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/alecthomas/chroma/v2 v2.17.2
 	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require github.com/dlclark/regexp2 v1.11.5 // indirect

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -96,6 +96,8 @@ func (h *Handler) handleDocsPath(w http.ResponseWriter, r *http.Request, path st
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			panic(err)
 		}
+		jsonConfig.HomePage = utils.FormatLocalPathString(jsonConfig.HomePage, ".md")
+		jsonConfig.Root = utils.FormatLocalPathString(jsonConfig.Root, ".md")
 	}
 
 	repoConfig := h.docsConfig

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -21,7 +21,7 @@ type Handler struct {
 }
 
 func NewHandler(config *config.Config, source source.Source, renderer render.Renderer, staticHandler http.Handler) *Handler {
-	return &Handler{source, renderer, staticHandler, config.HomePage}
+	return &Handler{source, renderer, staticHandler, config.Config.HomePage}
 }
 
 func (h *Handler) GithubPushHandler(w http.ResponseWriter, r *http.Request) {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,12 +17,11 @@ type Handler struct {
 	source        source.Source
 	renderer      render.Renderer
 	staticHandler http.Handler // the handler that will serve static files
-	homePage      string
 	docsConfig    *config.DocsConfig
 }
 
 func NewHandler(config *config.Config, source source.Source, renderer render.Renderer, staticHandler http.Handler) *Handler {
-	return &Handler{source, renderer, staticHandler, config.Config.HomePage, &config.Config}
+	return &Handler{source, renderer, staticHandler, &config.Config}
 }
 
 func (h *Handler) GithubPushHandler(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +71,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if path == "/" {
-		h.handleDocsPath(w, r, h.homePage)
+		h.handleDocsPath(w, r, h.docsConfig.HomePage)
 		return
 	}
 
@@ -96,7 +95,6 @@ func (h *Handler) handleDocsPath(w http.ResponseWriter, r *http.Request, path st
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			panic(err)
 		}
-		jsonConfig.HomePage = utils.FormatLocalPathString(jsonConfig.HomePage, ".md")
 		jsonConfig.Root = utils.FormatLocalPathString(jsonConfig.Root, ".md")
 	}
 
@@ -125,8 +123,6 @@ func (h *Handler) handleDocsPath(w http.ResponseWriter, r *http.Request, path st
 	} else {
 		renderConfig.HighlightStyle = queryConfig.HighlightStyle
 	}
-
-	renderConfig.HomePage = repoConfig.HomePage
 
 	html, err := h.renderer.RenderFile(path, renderConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	done := make(chan error)
 	go func() {
-		address := fmt.Sprintf("0.0.0.0:%s", config.Port)
+		address := fmt.Sprintf("0.0.0.0:%s", config.Envs.Port)
 		log.Printf("[Server] Starting server on %s\n", address)
 
 		err := http.ListenAndServe(address, router)

--- a/render/highlight.go
+++ b/render/highlight.go
@@ -33,7 +33,7 @@ func (r *RealRenderer) renderCodeBlock(w io.Writer, codeBlock *ast.CodeBlock, en
 }
 
 func (r *RealRenderer) getHighlightStyle(config *RenderConfig) error {
-	styleName := config.StyleName
+	styleName := config.HighlightStyle
 	if styleName == "" {
 		styleName = "tokyonight"
 	}

--- a/render/render.go
+++ b/render/render.go
@@ -89,6 +89,6 @@ func (r *RealRenderer) fixupLink(link *ast.Link, entering bool, config *RenderCo
 	if bytes.HasPrefix(link.Destination, []byte("http")) {
 		link.AdditionalAttributes = append(link.AdditionalAttributes, "target=\"_blank\"")
 	} else {
-		link.Destination = slices.Concat([]byte(config.RootPath), utils.FormatLocalPath(link.Destination, ".md"))
+		link.Destination = slices.Concat([]byte(config.Root), utils.FormatLocalPath(link.Destination, ".md"))
 	}
 }

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/PiquelOrganization/docs.piquel.fr/config"
 	"github.com/PiquelOrganization/docs.piquel.fr/source"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters/html"
@@ -15,10 +16,7 @@ type Renderer interface {
 }
 
 type RenderConfig struct {
-	RootPath    string // this will be prepended to any local URLs in the markdown
-	UseTailwind bool   // wether to use tailwind classes and settings (notably restore the proper size of titles)
-	FullPage    bool   // wether to render a full page (add <!DOCTYPE html> to the top of the page
-	StyleName   string // The name of the style used to format code blocks
+	config.DocsConfig
 
 	highlightStyle *chroma.Style // the style used to format code blocks
 }

--- a/source/source.go
+++ b/source/source.go
@@ -48,11 +48,14 @@ func (s *GitSource) Update() error {
 	}
 
 	configData, err := os.ReadFile(fmt.Sprintf("%s/config.yml", s.dataPath))
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		configData, err = os.ReadFile(fmt.Sprintf("%s/config.yaml", s.dataPath))
 		if errors.Is(err, os.ErrNotExist) {
 			log.Printf("[Source] Could not find configuration file in repository")
 			return nil
 		}
+	}
+	if err != nil {
 		return err
 	}
 

--- a/source/source.go
+++ b/source/source.go
@@ -42,6 +42,8 @@ func (s *GitSource) Update() error {
 		}
 	}
 
+	// TODO: update the configuration
+
 	return nil
 }
 

--- a/source/source.go
+++ b/source/source.go
@@ -24,8 +24,8 @@ type GitSource struct {
 
 func NewGitSource(config *config.Config) Source {
 	return &GitSource{
-		dataPath:   config.DataPath,
-		repository: config.Repository,
+		dataPath:   config.Envs.DataPath,
+		repository: config.Envs.Repository,
 	}
 }
 

--- a/source/source.go
+++ b/source/source.go
@@ -63,6 +63,10 @@ func (s *GitSource) Update() error {
 	if err = yaml.Unmarshal(configData, &s.docsConfig); err != nil {
 		return err
 	}
+
+	s.docsConfig.HomePage = utils.FormatLocalPathString(s.docsConfig.HomePage, ".md")
+	s.docsConfig.Root = utils.FormatLocalPathString(s.docsConfig.Root, ".md")
+
 	s.docsConfig.Unlock()
 
 	return nil


### PR DESCRIPTION
## Summary of the PR

A refactor of the configuration system to allow for config in the repository itself. Also allow for configuration in request json payload & query parameters. Order of relevance: query params -> json payload -> repo config

## Steps before PR review

- [x] Validate all checks
- [x] Properly document the feature in the PR (and docs when we have some)
- [x] Allow `.yaml` files (not just `.yml`)
- [x] Add config in json payload of request
- [x] Add remaining config to query params
- [x] Build the render config from three sources & priority
- [x] Add `FullPage` config param
- [x] Test config system (query params & json)

* Issues linked to the PR: #12 #11

## Changes

- Break `Config` type into subtypes
- `Envs` is system & router config
- `DocsConfig` is for the documentation specific config (linked to file in repo)
- Add parsing of yaml file in `source.Update`
- Add all new params to qurery params
- Allow parameters from json payload
- Build `renderConfig` from query, json & repo params in that order of importance